### PR TITLE
Enhance Magnifier Functionality for Cross-Mode Compatibility

### DIFF
--- a/html-magnifier.js
+++ b/html-magnifier.js
@@ -135,8 +135,8 @@
     function syncViewport() {
       const x1 = magnifier.offsetLeft;
       const y1 = magnifier.offsetTop;
-      const x2 = document.body.scrollLeft;
-      const y2 = document.body.scrollTop;
+      const x2 = window.pageXOffset || document.documentElement.scrollLeft;
+      const y2 = window.pageYOffset || document.documentElement.scrollTop;
       const left = -x1 * _this.options.zoom - x2 * _this.options.zoom;
       const top = -y1 * _this.options.zoom - y2 * _this.options.zoom;
       setPosition(magnifierContent, left, top);
@@ -241,7 +241,6 @@
     }
 
     function makeDraggable(ctrl, options) {
-
       const _this = this;
 
       let dragObject = null;
@@ -435,7 +434,7 @@
     };
 
     init();
-
+    
     return _this;
 
   }


### PR DESCRIPTION
This pull request addresses an issue where the magnifier feature failed to synchronize correctly when scrolling across different document modes (standards mode and quirks mode). 

The fix involves updating the logic for calculating scroll offsets to ensure compatibility with both modes. By prioritizing window.pageXOffset and window.pageYOffset for scroll positions which works in both standards and quirks mode, and falling back to document.documentElement.scrollLeft/document.documentElement.scrollTop where necessary (when older browsers are used), we achieve consistent behavior across all browsers and document modes. 

This update ensures a seamless user experience with the magnifier feature regardless of the document rendering mode.

Note: document.documentElement.scrollLeft and document.documentElement.scrollTop only works in standards mode